### PR TITLE
show staked crypto wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ Usage
 Version history
 ---------------
 
+* 1.21:
+    * show wallets for staked cryptos
+
 * 1.2:
     * added ETF and ETC (Ressource) wallets
 

--- a/bitpanda.lua
+++ b/bitpanda.lua
@@ -26,7 +26,7 @@
 -- SOFTWARE.
 
 
-WebBanking{version     = 1.2,
+WebBanking{version     = 1.21,
            url         = "https://api.bitpanda.com/v1/",
            services    = {"bitpanda"},
            description = "Loads FIATs, Krypto, Indizes, Stocks, ETCs (Ressources) and Commodities from bitpanda"}
@@ -295,7 +295,7 @@ function RefreshAccount (account, since)
         return
       end
       for index, cryptTransaction in pairs(getTrans) do
-        if tonumber(cryptTransaction.attributes.balance) > 0 then
+        if tonumber(cryptTransaction.attributes.balance) >= 0 then
           local transaction = transactionForCryptTransaction(cryptTransaction, account.currency, account.subAccount)
           t[#t + 1] = transaction
         end


### PR DESCRIPTION
fixed Problem that staked Crypto not shown in wallet list. depending on how many percent are staked, the crypto will be shown with an amount of 0 if 100% are staked.